### PR TITLE
Add `applyTableAttributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ Default: `false`
 
 Whether to use any CSS pixel widths to create `width` attributes on elements.
 
+#### options.applyTableAttributes
+
+Type: `Boolean`
+Default: `false`
+
+Whether to apply the `border`, `cellpadding` and `cellspacing` attributes to `table` elements.
+
 ## License
 
 MIT © [Jonathan Kemp](http://jonkemp.com)

--- a/index.js
+++ b/index.js
@@ -46,8 +46,9 @@ module.exports = function (html, options, callback) {
             applyLinkTags: true,
             removeLinkTags: true,
             preserveMediaQueries: false,
-            applyWidthAttributes: false,
             removeHtmlSelectors: false,
+            applyWidthAttributes: false,
+            applyTableAttributes: false
         }, options);
 
     inlineContent(html, opt, function (err, content) {

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -122,11 +122,29 @@ module.exports = function (html, css, options) {
         });
     }
 
+    function setTableAttrs(index, el) {
+        var $el = $(el);
+        if ($el.attr('border') == null) {
+            $el.attr('border', 0);
+        }
+        if ($el.attr('cellpadding') == null) {
+            $el.attr('cellpadding', 0);
+        }
+        if ($el.attr('cellspacing') == null) {
+            $el.attr('cellspacing', 0);
+        }
+    }
+
     rules.forEach(handleRule);
     editedElements.forEach(setStyleAttrs);
 
-    if (options && options.applyWidthAttributes) {
-        editedElements.forEach(setWidthAttrs);
+    if (options) {
+        if (options.applyWidthAttributes) {
+            editedElements.forEach(setWidthAttrs);
+        }
+        if (options.applyTableAttributes) {
+            $('table').each(setTableAttrs);
+        }
     }
 
     if (options && options.removeHtmlSelectors) {

--- a/test/expected/table-attr.html
+++ b/test/expected/table-attr.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+</head>
+<body>
+    <table border="0" cellpadding="0" cellspacing="0">
+        <tr>
+            <td>
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td>
+                            empty
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    <table border="1" cellpadding="2" cellspacing="3">
+        <tr>
+            <td>
+                empty
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/test/fixtures/table-attr.html
+++ b/test/fixtures/table-attr.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+</head>
+<body>
+    <table>
+        <tr>
+            <td>
+                <table border="0">
+                    <tr>
+                        <td>
+                            empty
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    <table border="1" cellpadding="2" cellspacing="3">
+        <tr>
+            <td>
+                empty
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -24,6 +24,11 @@ function compare(fixturePath, expectedPath, options, done) {
     options.url = 'file://' + file.path;
 
     inlineCss(file.contents.toString('utf8'), options, function (err, html) {
+
+        if (err) {
+            return done(err);
+        }
+
         html.should.be.equal(String(fs.readFileSync(expectedPath)));
 
         done();
@@ -197,6 +202,15 @@ describe('inline-css', function() {
             applyWidthAttributes: true
         };
         compare(path.join('test', 'fixtures', 'width-attr.html'), path.join('test', 'expected', 'width-attr.html'), options, done);
+    });
+
+    it('Should inline css and create table attributes on table elements', function(done) {
+        var options = {
+            url: './',
+            removeStyleTags: true,
+            applyTableAttributes: true
+        };
+        compare(path.join('test', 'fixtures', 'table-attr.html'), path.join('test', 'expected', 'table-attr.html'), options, done);
     });
 
     it('Should inline css in HTML templates', function(done) {


### PR DESCRIPTION
Allows table elements to automatically get sensible default attributes if they have not been set already.