### PR TITLE
Add option to apply height attributes to elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ Default: `false`
 
 Whether to use any CSS pixel widths to create `width` attributes on elements.
 
+#### options.applyHeightAttributes
+
+Type: `Boolean`  
+Default: `false`
+
+Whether to use any CSS pixel heights to create `height` attributes on elements.
+
 #### options.applyTableAttributes
 
 Type: `Boolean`

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = function (html, options, callback) {
             preserveMediaQueries: false,
             removeHtmlSelectors: false,
             applyWidthAttributes: false,
+            applyHeightAttributes: false,
             applyTableAttributes: false
         }, options);
 

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -7,7 +7,7 @@ var parseCSS = require('css-rules'),
     styleSelector = new Selector('<style attribute>', [1, 0, 0, 0]),
     importantSelector = new Selector('<!important>', [2, 0, 0, 0]),
     ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'],
-    widthElements = ['table', 'td', 'img'];
+    heightWidthElements = ['table', 'td', 'img'];
 
 module.exports = function (html, css, options) {
     var rules = parseCSS(css),
@@ -99,11 +99,23 @@ module.exports = function (html, css, options) {
     }
 
     function setWidthAttrs(el) {
-        if (widthElements.indexOf(el.name) > -1) {
+        if (heightWidthElements.indexOf(el.name) > -1) {
             for (var i in el.styleProps) {
                 if (el.styleProps[i].prop === 'width' && el.styleProps[i].value.match(/px/)) {
                     var pxWidth = el.styleProps[i].value.replace('px', '');
                     $(el).attr('width', pxWidth);
+                    return;
+                }
+            }
+        }
+    }
+
+    function setHeightAttrs(el) {
+        if (heightWidthElements.indexOf(el.name) > -1) {
+            for (var i in el.styleProps) {
+                if (el.styleProps[i].prop === 'height' && el.styleProps[i].value.match(/px/)) {
+                    var pxHeight = el.styleProps[i].value.replace('px', '');
+                    $(el).attr('height', pxHeight);
                     return;
                 }
             }
@@ -145,6 +157,10 @@ module.exports = function (html, css, options) {
         if (options.applyTableAttributes) {
             $('table').each(setTableAttrs);
         }
+    }
+
+    if (options && options.applyHeightAttributes) {
+        editedElements.forEach(setHeightAttrs);
     }
 
     if (options && options.removeHtmlSelectors) {

--- a/test/expected/height-attr.html
+++ b/test/expected/height-attr.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    
+</head>
+<body>
+    <p style="height: 200px;">none</p>
+    <table>
+        <tr>
+            <td style="height: 200px;" height="200">
+                tall
+            </td>
+        </tr>
+    </table>
+    <img src="" alt="tall" style="height: 200px;" height="200">
+</body>
+</html>

--- a/test/fixtures/height-attr.html
+++ b/test/fixtures/height-attr.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <style>
+        p, td, img {
+            height: 200px;
+        }
+    </style>
+</head>
+<body>
+    <p>none</p>
+    <table>
+        <tr>
+            <td>
+                tall
+            </td>
+        </tr>
+    </table>
+    <img src="" alt="tall">
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -204,6 +204,15 @@ describe('inline-css', function() {
         compare(path.join('test', 'fixtures', 'width-attr.html'), path.join('test', 'expected', 'width-attr.html'), options, done);
     });
 
+    it('Should inline css and create height attributes on elements', function(done) {
+        var options = {
+            url: './',
+            removeStyleTags: true,
+            applyHeightAttributes: true
+        };
+        compare(path.join('test', 'fixtures', 'height-attr.html'), path.join('test', 'expected', 'height-attr.html'), options, done);
+    });
+
     it('Should inline css and create table attributes on table elements', function(done) {
         var options = {
             url: './',


### PR DESCRIPTION
I spun off option.applyWidthAttributes into option.applyHeightAttributes. This is useful for maintaining layout in HTML emails before images have been loaded.