### PR TITLE
Fix CSS syntax in media test

### DIFF
--- a/test/fixtures/media.css
+++ b/test/fixtures/media.css
@@ -1,3 +1,5 @@
 @media only screen and (-webkit-min-device-pixel-ratio: 2) {
-  color: blue;
+  p {
+    color: blue;
+  }
 }


### PR DESCRIPTION
It was missing a selector so the CSS wasn't valid. Doesn't test the test case.