### PR TITLE
Set more table attributes

### DIFF
--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -9,6 +9,32 @@ var parseCSS = require('css-rules'),
     ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'],
     widthElements = ['table', 'td', 'img'];
 
+var tableStyleAttrMap = {
+    'table': {
+        'float': 'align',
+        'background-color': 'bgcolor',
+        'width': 'width',
+        'height': 'height'
+    },
+    'tr': {
+        'background-color': 'bgcolor',
+        'vertical-align': 'valign',
+        'text-align': 'align'
+    },
+    'td,th': {
+        'background-color': 'bgcolor',
+        'width': 'width',
+        'height': 'height',
+        'vertical-align': 'valign',
+        'text-align': 'align',
+        'white-space': 'nowrap'
+    },
+    'tbody,thead,tfoot': {
+        'vertical-align': 'valign',
+        'text-align': 'align'
+    }
+};
+
 module.exports = function (html, css, options) {
     var rules = parseCSS(css),
         editedElements = [],
@@ -138,6 +164,16 @@ module.exports = function (html, css, options) {
         });
     }
 
+    function applyStylesAsProps($el, styleToAttrMap) {
+        for (var style in styleToAttrMap) {
+            var styleVal = $el.css(style);
+            if (styleVal != undefined) {
+                $el.attr(styleToAttrMap[style], styleVal);
+                $el.css(style, '');
+            }
+        }
+    }
+
     function setTableAttrs(index, el) {
         var $el = $(el);
 
@@ -149,6 +185,18 @@ module.exports = function (html, css, options) {
         }
         if (!$el.attr('cellspacing')) {
             $el.attr('cellspacing', 0);
+        }
+
+
+
+        for (var selector in tableStyleAttrMap){
+            if (selector == 'table'){
+                applyStylesAsProps($el, tableStyleAttrMap['table']);
+            } else {
+                $el.find(selector).each(function(i, childEl){
+                    applyStylesAsProps($(childEl), tableStyleAttrMap[selector]);
+                });
+            }
         }
     }
 

--- a/test/expected/table-attr.html
+++ b/test/expected/table-attr.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+
 </head>
 <body>
     <table border="0" cellpadding="0" cellspacing="0">
@@ -21,6 +22,29 @@
                 empty
             </td>
         </tr>
+    </table>
+    <table class="table" style="" border="0" cellpadding="0" cellspacing="0" align="left" bgcolor="red" width="100%" height="500px">
+        <thead class="thead" style="" valign="baseline" align="center">
+            <tr>
+                <th class="th" style="" bgcolor="green" width="50%" height="250px" valign="bottom" align="right" nowrap="nowrap">
+                    th
+                </th>
+            </tr>
+        </thead>
+        <tbody class="tbody" style="" valign="baseline" align="center">
+            <tr class="tr" style="" bgcolor="blue" valign="top" align="left">
+                <td class="td" style="" bgcolor="green" width="50%" height="250px" valign="bottom" align="right" nowrap="nowrap">
+                    td
+                </td>
+            </tr>
+        </tbody>
+        <tfoot class="tfoot" style="" valign="baseline" align="center">
+            <tr>
+                <td>
+                    td
+                </td>
+            </tr>
+        </tfoot>
     </table>
 </body>
 </html>

--- a/test/fixtures/table-attr.html
+++ b/test/fixtures/table-attr.html
@@ -1,5 +1,30 @@
 <html>
 <head>
+<style>
+    .table {
+        background-color: red;
+        float: left;
+        width: 100%;
+        height: 500px;
+    }
+    .tr {
+        background-color: blue;
+        vertical-align: top;
+        text-align: left;
+    }
+    .th, .td {
+        background-color: green;
+        width: 50%;
+        height: 250px;
+        vertical-align: bottom;
+        text-align: right;
+        white-space: nowrap;
+    }
+    .thead, .tbody, .tfoot {
+        vertical-align: baseline;
+        text-align: center;
+    }
+</style>
 </head>
 <body>
     <table>
@@ -21,6 +46,29 @@
                 empty
             </td>
         </tr>
+    </table>
+    <table class="table">
+        <thead class="thead">
+            <tr>
+                <th class="th">
+                    th
+                </th>
+            </tr>
+        </thead>
+        <tbody class="tbody">
+            <tr class="tr">
+                <td class="td">
+                    td
+                </td>
+            </tr>
+        </tbody>
+        <tfoot class="tfoot">
+            <tr>
+                <td>
+                    td
+                </td>
+            </tr>
+        </tfoot>
     </table>
 </body>
 </html>


### PR DESCRIPTION
We are using this module to inline css for use in emails. This obviously means lots of tables... FUN!

This PR expands the `applyTableAttributes` option to convert some css properties into attributes for `table`, `tr` and `td` tags.

I tried to follow what is listed on the W3 schools pages under the section "Differences Between HTML 4.01 and HTML5" for items where there is an obvious direct mapping.

Currently, I'm removing the styles in the style tag when I apply the attributes. If any email css experts can weigh in, they may know what is best.

One thing this does not handle is the short form of background colors. Example setting css of  `background: blue` will not be put into the `bgcolor` property. This could be added however using something like https://www.npmjs.com/package/css-shorthand-expand.

Another future improvement would be to convert background colors using best practices (see https://litmus.com/blog/background-colors-html-email)
