### PR TITLE
Accept cheerio options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,14 @@
 'use strict';
 
-var Promise = require('bluebird'),
+var extend = require('./lib/extend'),
+    Promise = require('bluebird'),
     inlineContent = require('./lib/inlineContent');
-
-function extend(obj, src) {
-    var key,
-        own = {}.hasOwnProperty;
-
-    for (key in src) {
-        if (own.call(src, key)) {
-            obj[key] = src[key];
-        }
-    }
-    return obj;
-}
 
 module.exports = function (html, options) {
     return new Promise(function (resolve, reject) {
         var opt = extend({
             extraCss: '',
+            cheerioOptions: {},
             applyStyleTags: true,
             removeStyleTags: true,
             applyLinkTags: true,

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function (obj, src) {
+    var key,
+        own = {}.hasOwnProperty;
+
+    for (key in src) {
+        if (own.call(src, key)) {
+            obj[key] = src[key];
+        }
+    }
+    return obj;
+};

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -4,6 +4,7 @@ var parseCSS = require('css-rules'),
     cheerio = require('cheerio'),
     pseudoCheck = require('./pseudoCheck'),
     handleRule = require('./handleRule'),
+    extend = require('./extend'),
     flatten = require('flatten'),
     setStyleAttrs = require('./setStyleAttrs'),
     setWidthAttrs = require('./setWidthAttrs'),
@@ -14,9 +15,9 @@ module.exports = function (html, css, options) {
     var opts = options || {},
         rules = parseCSS(css),
         editedElements = [],
-        $ = cheerio.load(html, {
+        $ = cheerio.load(html, extend({
             decodeEntities: false
-        });
+        }, options.cheerioOptions));
 
     rules.forEach(function (rule) {
         var el,


### PR DESCRIPTION
This library works great on SVG (and is necessary for using [svg sprites](https://css-tricks.com/svg-symbol-good-choice-icons/) w/ Illustrator-generated svg's), except that it lowercases all tag names & attribute names. Cheerio accepts options to fix that, but right now there's no way to pass options to cheerio.

This patch adds one optional field: `cheerioOptions`, which will get passed into cheerio whenever it parses (this requires a few changes "down the chain" in some dependent repo's. I'm posting PR's to those also).

If this is something you're interested in, I'll be happy to add a couple tests and a note in the README.

As far as pulling out `extend` - I'd recommend we just depend on the `extend` module. (Which is what I did in the dependent repos)

Thanks!