### PR TITLE
Option to move <style> tag to <body>

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Default: `false`
 
 Whether to remove the `class` and `id` attributes from the markup.
 
+#### options.moveStyleTag
+
+Type: `Boolean`
+Default: `false`
+
+Whether to move the `<style>` tag out of `<head>` and into the top of `<body>`.
+
 ### cheerio options
 
 Options to passed to [cheerio](https://github.com/cheeriojs/cheerio).

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ module.exports = function (html, options) {
             lowerCaseTags: true,
             lowerCaseAttributeNames: false,
             recognizeCDATA: false,
-            recognizeSelfClosing: false
+            recognizeSelfClosing: false,
+            moveStyleTag: false
         }, options);
 
         inlineContent(html, opt)

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -71,5 +71,9 @@ module.exports = function (html, css, options) {
         });
     }
 
+    if (opts.moveStyleTag) {
+        $('body').prepend($('style'));
+    }
+
     return $.html();
 };

--- a/test/expected/move-style-tag.html
+++ b/test/expected/move-style-tag.html
@@ -1,0 +1,7 @@
+<html><head></head><body><style>
+@media  {
+  p {
+    color: red;
+  }
+}
+</style><p></p></body></html>

--- a/test/fixtures/move-style-tag.html
+++ b/test/fixtures/move-style-tag.html
@@ -1,0 +1,1 @@
+<html><head><style>@media { p { color: red; } }</style></head><body><p></p></body></html>

--- a/test/main.js
+++ b/test/main.js
@@ -258,4 +258,12 @@ describe('inline-css', function() {
                 done();
             });
     });
+
+    it('Should move the <style> tag to <body> if options.moveStyleTag is true', function(done) {
+        var options = {
+            moveStyleTag: true,
+            preserveMediaQueries: true
+        };
+        compare(path.join('test', 'fixtures', 'move-style-tag.html'), path.join('test', 'expected', 'move-style-tag.html'), options, done);
+    });
 });


### PR DESCRIPTION
Gmail and Outlook remove the entirety of the `<head>` tag of an HTML email when rendering them. When inlining CSS for email, it's considered a best practice to place the `<style>` tag as the first child of the `<body>`, so it isn't stripped out.

This pull request adds a `moveStyleTag` option which moves the `<style>` tag to the `<body>` when enabled. The process of moving happens at the very end, after all the inlining is done.
