### PR TITLE
Add test for XHTML support

### DIFF
--- a/test/expected/xhtml.html
+++ b/test/expected/xhtml.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta name="viewport" content="width=device-width"/>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+  <img src="/image.jpg"/>
+</body>
+</html>

--- a/test/fixtures/xhtml.html
+++ b/test/fixtures/xhtml.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta name="viewport" content="width=device-width" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+  <img src="/image.jpg" />
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -258,4 +258,11 @@ describe('inline-css', function() {
                 done();
             });
     });
+
+    it('Should handle xhtml documents correctly', function(done) {
+        var options = {
+           xmlMode: true
+        };
+        compare(path.join('test', 'fixtures', 'xhtml.html'), path.join('test', 'expected', 'xhtml.html'), options, done);
+    });
 });


### PR DESCRIPTION
Started to add support for XHTML by creating a test then saw it was already supported in master via `xmlMode: true`  Here's the test for good measure.