### PR TITLE
Two New Options: applyHeightAttributes and applyCenterAttributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (html, options) {
             preserveMediaQueries: false,
             removeHtmlSelectors: false,
             applyWidthAttributes: false,
+            applyHeightAttributes: false,
             applyTableAttributes: false,
             xmlMode: false,
             decodeEntities: false,

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (html, options) {
             removeHtmlSelectors: false,
             applyWidthAttributes: false,
             applyHeightAttributes: false,
+            applyCenterAttributes: false,
             applyTableAttributes: false,
             xmlMode: false,
             decodeEntities: false,

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -60,6 +60,10 @@ module.exports = function (html, css, options) {
             setWidthAttrs(el, $);
         }
 
+        if (opts.applyHeightAttributes) {
+            setHeightAttrs(el, $);
+        }
+
         if (opts.removeHtmlSelectors) {
             removeClassId(el, $);
         }

--- a/lib/inline-css.js
+++ b/lib/inline-css.js
@@ -6,7 +6,9 @@ var parseCSS = require('css-rules'),
     handleRule = require('./handleRule'),
     flatten = require('flatten'),
     setStyleAttrs = require('./setStyleAttrs'),
+    setHeightAttrs = require('./setHeightAttrs'),
     setWidthAttrs = require('./setWidthAttrs'),
+    setCenterAttrs = require('./setCenterAttrs'),
     removeClassId = require('./removeClassId'),
     setTableAttrs = require('./setTableAttrs'),
     pick = require('object.pick');
@@ -62,6 +64,10 @@ module.exports = function (html, css, options) {
 
         if (opts.applyHeightAttributes) {
             setHeightAttrs(el, $);
+        }
+
+        if (opts.applyCenterAttributes) {
+            setCenterAttrs(el, $);
         }
 
         if (opts.removeHtmlSelectors) {

--- a/lib/setCenterAttrs.js
+++ b/lib/setCenterAttrs.js
@@ -1,14 +1,30 @@
 'use strict';
 
-var centerElements = [ 'table', 'td', 'img' ];
+var centerElements = [ 'img' ];
+var centerContainers = [ 'table' ];
 
 module.exports = function (el, $) {
-    var i;
+    var i,
+        wrapper;
 
     if (centerElements.indexOf(el.name) > -1) {
         for (i in el.styleProps) {
             if (el.styleProps[i].prop === 'margin' && el.styleProps[i].value.match(/auto/)) {
+                // create wrapper container
+                wrapper = $('<center>' + $(el).toString() + '</center>');
+
+                $(el).replaceWith(wrapper);
+
+                return;
+            }
+        }
+    }
+
+    if (centerContainers.indexOf(el.name) > -1) {
+        for (i in el.styleProps) {
+            if (el.styleProps[i].prop === 'margin' && el.styleProps[i].value.match(/auto/)) {
                 $(el).attr('align', 'center');
+
                 return;
             }
         }

--- a/lib/setCenterAttrs.js
+++ b/lib/setCenterAttrs.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var centerElements = [ 'table', 'td', 'img' ];
+
+module.exports = function (el, $) {
+    var i;
+
+    if (centerElements.indexOf(el.name) > -1) {
+        for (i in el.styleProps) {
+            if (el.styleProps[i].prop === 'margin' && el.styleProps[i].value.match(/auto/)) {
+                $(el).attr('align', 'center');
+                return;
+            }
+        }
+    }
+};

--- a/lib/setHeightAttrs.js
+++ b/lib/setHeightAttrs.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var heightElements = [ 'table', 'td', 'img' ];
+
+module.exports = function (el, $) {
+    var i,
+        pxHeight;
+
+    if (heightElements.indexOf(el.name) > -1) {
+        for (i in el.styleProps) {
+            if (el.styleProps[i].prop === 'height' && el.styleProps[i].value.match(/px/)) {
+                pxHeight = el.styleProps[i].value.replace('px', '');
+
+                $(el).attr('height', pxHeight);
+                return;
+            }
+        }
+    }
+};


### PR DESCRIPTION
These updates are very exclusively for email development, specifically more awful clients like Outlook 2013.

- applyHeightAttributes does exactly what applyWidthAttributes does, but with height!
- applyCenterAttributes with check to see if `margin: auto` (or some variant with `auto`) is applied. If the element is an image, it's wrapped in a `<center>` element. If it's a table, the attribute `align="center"` is added.
