### PR TITLE
migrate to safe Buffer constructor method

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -14,7 +14,7 @@ function getFile(filePath) {
         path: path.resolve(filePath),
         cwd: './test/',
         base: path.dirname(filePath),
-        contents: new Buffer(String(fs.readFileSync(filePath)))
+        contents: Buffer.from(String(fs.readFileSync(filePath)))
     });
 }
 


### PR DESCRIPTION
Running `npm test` generates the following warning: 

```
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
The `new Buffer()` constructor is replaced with `Buffer.from()` to fix the deprecation warning.

See here for more info: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/