### PR TITLE
Strip 'px' from numeric values when inlining table,td,th height and width attributes

### DIFF
--- a/lib/setTableAttrs.js
+++ b/lib/setTableAttrs.js
@@ -26,7 +26,7 @@ var cheerio = require('cheerio'),
             'text-align': 'align'
         }
     },
-    attributesToRemovePxFrom = ['height', 'width'],
+    attributesToRemovePxFrom = [ 'height', 'width' ],
     applyStylesAsProps = function ($el, styleToAttrMap) {
         var style,
             styleVal,
@@ -36,10 +36,11 @@ var cheerio = require('cheerio'),
             styleVal = $el.css(style);
 
             if (styleVal !== undefined) {
-                if(attributesToRemovePxFrom.indexOf(style) > -1)
+                if (attributesToRemovePxFrom.indexOf(style) > -1) {
                     attributeValue = styleVal.replace(/px$/i, '');
-                else
+                } else {
                     attributeValue = styleVal;
+                }
 
                 $el.attr(styleToAttrMap[style], attributeValue);
                 $el.css(style, '');

--- a/lib/setTableAttrs.js
+++ b/lib/setTableAttrs.js
@@ -29,20 +29,19 @@ var cheerio = require('cheerio'),
     attributesToRemovePxFrom = ['height', 'width'],
     applyStylesAsProps = function ($el, styleToAttrMap) {
         var style,
-            styleVal;
+            styleVal,
+            attributeValue;
 
         for (style in styleToAttrMap) {
             styleVal = $el.css(style);
 
             if (styleVal !== undefined) {
-                $el.attr(
-                    styleToAttrMap[style],
-                    (attributesToRemovePxFrom.indexOf(style) > -1)
-                        ?
-                        styleVal.replace(/px$/i, '')
-                        :
-                        styleVal
-                );
+                if(attributesToRemovePxFrom.indexOf(style) > -1)
+                    attributeValue = styleVal.replace(/px$/i, '');
+                else
+                    attributeValue = styleVal;
+
+                $el.attr(styleToAttrMap[style], attributeValue);
                 $el.css(style, '');
             }
         }

--- a/lib/setTableAttrs.js
+++ b/lib/setTableAttrs.js
@@ -26,6 +26,7 @@ var cheerio = require('cheerio'),
             'text-align': 'align'
         }
     },
+    attributesToRemovePxFrom = ['height', 'width'],
     applyStylesAsProps = function ($el, styleToAttrMap) {
         var style,
             styleVal;
@@ -34,7 +35,14 @@ var cheerio = require('cheerio'),
             styleVal = $el.css(style);
 
             if (styleVal !== undefined) {
-                $el.attr(styleToAttrMap[style], styleVal);
+                $el.attr(
+                    styleToAttrMap[style],
+                    (attributesToRemovePxFrom.indexOf(style) > -1)
+                        ?
+                        styleVal.replace(/px$/i, '')
+                        :
+                        styleVal
+                );
                 $el.css(style, '');
             }
         }

--- a/test/expected/table-attr.html
+++ b/test/expected/table-attr.html
@@ -23,17 +23,17 @@
             </td>
         </tr>
     </table>
-    <table class="table" style="" border="0" cellpadding="0" cellspacing="0" align="left" bgcolor="red" width="100%" height="500px">
+    <table class="table" style="" border="0" cellpadding="0" cellspacing="0" align="left" bgcolor="red" width="100%" height="500">
         <thead class="thead" style="" valign="baseline" align="center">
             <tr>
-                <th class="th" style="" bgcolor="green" width="50%" height="250px" valign="bottom" align="right" nowrap="nowrap">
+                <th class="th" style="" bgcolor="green" width="50%" height="250" valign="bottom" align="right" nowrap="nowrap">
                     th
                 </th>
             </tr>
         </thead>
         <tbody class="tbody" style="" valign="baseline" align="center">
             <tr class="tr" style="" bgcolor="blue" valign="top" align="left">
-                <td class="td" style="" bgcolor="green" width="50%" height="250px" valign="bottom" align="right" nowrap="nowrap">
+                <td class="td" style="" bgcolor="green" width="50%" height="250" valign="bottom" align="right" nowrap="nowrap">
                     td
                 </td>
             </tr>

--- a/test/fixtures/table-attr.html
+++ b/test/fixtures/table-attr.html
@@ -5,7 +5,7 @@
         background-color: red;
         float: left;
         width: 100%;
-        height: 500px;
+        height: 500PX;
     }
     .tr {
         background-color: blue;


### PR DESCRIPTION
Correct format for inlining these values is width="200" vs width="200px". This PR handles case insensitive stripping of 'px' from the end of the attribute value when the key is height or width.